### PR TITLE
Fixes parse date issue which causes app to crash on Windows 10 (UWP APP)

### DIFF
--- a/Companion app/WindowsHelloWithLedger/MainPage.xaml.cs
+++ b/Companion app/WindowsHelloWithLedger/MainPage.xaml.cs
@@ -116,9 +116,22 @@ namespace LedgerHello
             return;
         }
 
+        private string ExtractDateFromDeviceInfo(SecondaryAuthenticationFactorInfo info)
+        {
+
+            string deviceConfigurationData = CryptographicBuffer.ConvertBinaryToString(0, info.DeviceConfigurationData);
+            string[] dcdArray = deviceConfigurationData.
+                                Replace(info.DeviceFriendlyName, "").
+                                Replace(info.DeviceId, "").
+                                Split('-');
+
+            return dcdArray[4];
+
+        }
+
+
         void RefreshDeviceList(IReadOnlyList<SecondaryAuthenticationFactorInfo> deviceList, int slectedIndex)
         {
-            string deviceConfigurationString;
             string dateString = string.Empty;
             listContent listItem;
             List<DateTime> dateList = new List<DateTime>();
@@ -126,13 +139,15 @@ namespace LedgerHello
             for (int index = 0; index < deviceList.Count; ++index)
             {
                 SecondaryAuthenticationFactorInfo deviceInfo = deviceList.ElementAt(index);
-                deviceConfigurationString = CryptographicBuffer.ConvertBinaryToString(0, deviceInfo.DeviceConfigurationData);
+                //Debug.WriteLine(deviceInfo.DeviceConfigurationData);
+
                 listItem = new listContent();
                 //DateTime now = DateTime.Now;
                 listItem.deviceFriendlyName = deviceInfo.DeviceFriendlyName;
+
                 listItem.deviceGUID = deviceInfo.DeviceId;
                 int count = deviceInfo.DeviceFriendlyName.Count();
-                listItem.date = DateTime.Parse(deviceConfigurationString.Substring(35 + 1 + count + 1 + 1, 19));
+                listItem.date = DateTime.Parse(ExtractDateFromDeviceInfo(deviceInfo));
                 dateString = CommomMethods.FormatDate(listItem.date);
                 listItem.dateString = dateString;
                 if (DeviceListBox.Items.Count > index - cpt)
@@ -144,12 +159,13 @@ namespace LedgerHello
             for (int index = 0; index < deviceList.Count; ++index)
             {
                 SecondaryAuthenticationFactorInfo deviceInfo = deviceList.ElementAt(index);
-                deviceConfigurationString = CryptographicBuffer.ConvertBinaryToString(0, deviceInfo.DeviceConfigurationData);
+
                 listItem = new listContent();
                 listItem.deviceFriendlyName = deviceInfo.DeviceFriendlyName;
                 listItem.deviceGUID = deviceInfo.DeviceId;
                 int count = deviceInfo.DeviceFriendlyName.Count();
-                listItem.date = DateTime.Parse(deviceConfigurationString.Substring(35 + 1 + count + 1 + 1, 19));
+
+                listItem.date = DateTime.Parse(ExtractDateFromDeviceInfo(deviceInfo));
                 dateString = CommomMethods.FormatDate(listItem.date);
                 listItem.dateString = dateString;
                 if (index == deviceList.Count - 1)
@@ -159,10 +175,12 @@ namespace LedgerHello
                 else
                 {
                     listItem.isVisible = true;
-                }                
+                }
                 DeviceListBox.Items.Add(listItem);
             }
         }
+
+
         private void StartWatcher()
         {
             DeviceWatcherEventKind[] triggerEventKinds = { DeviceWatcherEventKind.Add, DeviceWatcherEventKind.Remove/*, DeviceWatcherEventKind.Update */};


### PR DESCRIPTION
So what happens is depending on which date the device is added, string that represents the date in the ConfiguartionData can be either variable number of symbols - dd/m/YYYY, d/mm/YYYY, dd/mm/YYYY

So I coded it to split the string by '-' and making it so that users can use device names that include '-' as well.

This issue was causing crash on Windows 10 and makes the app unusable and can't remove Ledger device from Windows. It happens only when date string is smaller or larger than 19 expected char symbols.